### PR TITLE
Add bruno api routes for current service.

### DIFF
--- a/bruno/check/Check Transaction by Id.bru
+++ b/bruno/check/Check Transaction by Id.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Check Transaction by Id
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{winter}}/check/:id
+  body: none
+  auth: none
+}
+
+params:path {
+  id: 
+}

--- a/bruno/check/Check Transactions.bru
+++ b/bruno/check/Check Transactions.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Check Transactions
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{winter}}/check
+  body: none
+  auth: none
+}

--- a/bruno/ipfs/Metadata.bru
+++ b/bruno/ipfs/Metadata.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: /ipfs
+  url: {{winter}}/ipfs
   body: json
   auth: none
 }
@@ -22,7 +22,7 @@ body:json {
         "itemIdentifier": "<identifier>",
         "itemEventId": "<tokenId>",
         "itemQuantity": 500,
-        "unit": "kilograms"
+        "unit": "kg"
       }
     ],
     "outputItems": [
@@ -35,7 +35,7 @@ body:json {
     "metadata": [
       {
         "key": "Location",
-        "unit": "kilogram",
+        "unit": "kg",
         "value": "7.2905° N, 80.6337° E"
       }
     ]

--- a/bruno/palmyra/Commodity Details.bru
+++ b/bruno/palmyra/Commodity Details.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Commodity Details
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{winter]}/palmyra/commodityDetails
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "tokenIds": [
+      "802ad2b341d95e0f55fd02bf364f3fa28aae08abb3e304160e76e808617065"
+    ]
+  }
+}

--- a/bruno/palmyra/Recreate Commodity.bru
+++ b/bruno/palmyra/Recreate Commodity.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Recreate Commodity
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{winter}}/palmyra/recreateCommodity
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "utxos": [
+      {
+        "txHash": "cb52c73335b6495e1662747a6a69c335e5341eaf391086b192650564658ce4b9",
+        "outputIndex": 0
+      }
+    ],
+    "newDataReferences": [
+      "ipfs://someotherhash"
+    ]
+  }
+}

--- a/bruno/palmyra/Spend Commodity.bru
+++ b/bruno/palmyra/Spend Commodity.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Spend Commodity
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{winter}}/palmyra/spendCommodity
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "utxos": [
+      {
+        "txHash": "cb52c73335b6495e1662747a6a69c335e5341eaf391086b192650564658ce4b9",
+        "outputIndex": 0
+      }
+    ]
+  }
+}

--- a/bruno/palmyra/Tokenize Commodity.bru
+++ b/bruno/palmyra/Tokenize Commodity.bru
@@ -1,0 +1,18 @@
+meta {
+  name: Tokenize Commodity
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{winter}}/palmyra/tokenizeCommodity
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "tokenName": "test name",
+    "metadataReference": "ipfs://bafkreicee6unl6peffg4q6r4tnmd3zinwaizbxy3hg7dzkjzzk7kkmh4bi"
+  }
+}

--- a/bruno/transactions/Transaction by Id.bru
+++ b/bruno/transactions/Transaction by Id.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Transaction by Id
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{winter}}/transactions/:id
+  body: none
+  auth: none
+}
+
+params:path {
+  id: 
+}

--- a/bruno/transactions/Transactions.bru
+++ b/bruno/transactions/Transactions.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Transactions
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{winter}}/transactions
+  body: none
+  auth: none
+}


### PR DESCRIPTION
Adding [Bruno](https://usebruno.com) functionality to the backend so it is easier to test and play around with the exposed API routes when running locally. These routes will be updated in the future since we need to refactor the backend somewhat.